### PR TITLE
Add parsing support for sorting options in ListCommandParser (sorting functionality pending)

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.model.Model;
 
@@ -13,18 +12,46 @@ public class ListCommand extends Command {
     public static final String COMMAND_WORD = "list";
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SORT_NOT_IMPLEMENTED = "Sorting not yet implemented.";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all persons in the address book.\n"
+            + "Optional parameters: [s/SORT_OPTION]\n"
+            + "Example: " + COMMAND_WORD + " s/alphabet";
 
+    private final String sortOption;
+
+    public ListCommand() {
+        this.sortOption = null;
+    }
+
+    public ListCommand(String sortOption) {
+        this.sortOption = sortOption;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+
+        if (sortOption != null) {
+            // For now, we just inform the user that sorting is not implemented
+            return new CommandResult(MESSAGE_SORT_NOT_IMPLEMENTED);
+        }
         return new CommandResult(MESSAGE_SUCCESS);
     }
 
     @Override
     public boolean equals(Object other) {
-        // Since ListCommand has no fields, all instances are considered equal
-        return other instanceof ListCommand;
+        // If both commands have the same sortOption, they are considered equal
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof ListCommand)) {
+            return false;
+        }
+
+        ListCommand otherCommand = (ListCommand) other;
+        return (sortOption == null && otherCommand.sortOption == null)
+                || (sortOption != null && sortOption.equals(otherCommand.sortOption));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.model.Model;
 
@@ -30,7 +31,7 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         if (sortOption != null) {
             // For now, we just inform the user that sorting is not implemented

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-
+    public static final Prefix PREFIX_SORT = new Prefix("s/");
 }

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT;
+
+import java.util.Optional;
 
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -13,10 +16,28 @@ public class ListCommandParser implements Parser<ListCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the ListCommand
      * and returns a ListCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseException if the user input does not conform to the expected format
      */
     public ListCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        return new ListCommand();
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SORT);
+
+        // Ensure there are no duplicate sort prefixes
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_SORT);
+
+        Optional<String> sortOption = argMultimap.getValue(PREFIX_SORT);
+
+        if (sortOption.isEmpty()) {
+            // No sort option
+            return new ListCommand();
+        }
+
+        String sortOptionValue = sortOption.get().trim();
+
+        // For now, we accept any non-empty sort option
+        if (sortOptionValue.isEmpty()) {
+            throw new ParseException("Sort option cannot be empty.");
+        }
+        return new ListCommand(sortOptionValue);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -35,5 +37,34 @@ public class ListCommandTest {
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_withSortOption_showsNotImplementedMessage() {
+        // Create a ListCommand with a sort option (e.g., "alphabet")
+        ListCommand listCommandWithSort = new ListCommand("alphabet");
+
+        // The expected outcome should be the "Sorting not yet implemented" message
+        assertCommandSuccess(listCommandWithSort, model, ListCommand.MESSAGE_SORT_NOT_IMPLEMENTED, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        // Same ListCommand without sortOption should be equal
+        ListCommand listCommand1 = new ListCommand();
+        ListCommand listCommand2 = new ListCommand();
+        assertEquals(listCommand1, listCommand2);
+
+        // ListCommand with the same sortOption should be equal
+        ListCommand listCommandWithSort1 = new ListCommand("alphabet");
+        ListCommand listCommandWithSort2 = new ListCommand("alphabet");
+        assertEquals(listCommandWithSort1, listCommandWithSort2);
+
+        // ListCommand with different sortOptions should not be equal
+        ListCommand listCommandWithSort3 = new ListCommand("name");
+        assertNotEquals(listCommandWithSort1, listCommandWithSort3);
+
+        // ListCommand with and without sortOption should not be equal
+        assertNotEquals(listCommand1, listCommandWithSort1);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
@@ -1,30 +1,36 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.ListCommand;
 
 public class ListCommandParserTest {
 
-    private final ListCommandParser parser = new ListCommandParser();
+    private ListCommandParser parser = new ListCommandParser();
 
     @Test
-    public void parse_emptyArgs_returnsListCommand() {
-        // No arguments provided
+    public void parse_noArgs_returnsListCommand() {
         assertParseSuccess(parser, "", new ListCommand());
     }
 
     @Test
-    public void parse_whitespaceArg_returnsListCommand() {
-        // Whitespace arguments should be ignored
-        assertParseSuccess(parser, "   ", new ListCommand());
+    public void parse_validSortOption_returnsListCommand() {
+        assertParseSuccess(parser, " s/alphabet", new ListCommand("alphabet"));
     }
 
     @Test
-    public void parse_nonEmptyArgs_returnsListCommand() {
-        // Any non-empty arguments are ignored in current implementation
-        assertParseSuccess(parser, "some random arguments", new ListCommand());
+    public void parse_multipleValidSortOptions_throwsParseException() {
+        String expectedMessage = Messages.getErrorMessageForDuplicatePrefixes(PREFIX_SORT);
+        assertParseFailure(parser, " s/alphabet s/age", expectedMessage);
+    }
+
+    @Test
+    public void parse_emptySortOption_throwsParseException() {
+        assertParseFailure(parser, " s/", "Sort option cannot be empty.");
     }
 }


### PR DESCRIPTION
If a sorting option is entered, it will say that sorting has not been implemented yet. Sorting functionality will be implemented in the next iteration.

Closes #52 