### PR TITLE
Add SortOption class and parseSortOption method

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -3,6 +3,8 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.SortOption;
 import seedu.address.model.Model;
 
 /**
@@ -12,24 +14,25 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
-    public static final String MESSAGE_SORT_NOT_IMPLEMENTED = "Sorting not yet implemented.";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all persons in the address book.\n"
             + "Optional parameters: [s/SORT_OPTION]\n"
             + "Example: " + COMMAND_WORD + " s/alphabet";
 
-    private final String sortOption;
+    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SORT_NOT_IMPLEMENTED = "Sorting not yet implemented.";
+
+    private final SortOption sortOption;
 
     public ListCommand() {
         this.sortOption = null;
     }
 
-    public ListCommand(String sortOption) {
+    public ListCommand(SortOption sortOption) {
         this.sortOption = sortOption;
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -34,10 +34,12 @@ public class ListCommandParser implements Parser<ListCommand> {
 
         String sortOptionValue = sortOption.get().trim();
 
-        // For now, we accept any non-empty sort option
         if (sortOptionValue.isEmpty()) {
             throw new ParseException("Sort option cannot be empty.");
         }
-        return new ListCommand(sortOptionValue);
+
+        // Ensure sort option is supported
+        SortOption validSortOption = ParserUtil.parseSortOption(sortOptionValue);
+        return new ListCommand(validSortOption);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -121,4 +121,19 @@ public class ParserUtil {
         }
         return tagSet;
     }
+
+    /**
+     * Parses a {@code String sortOption} into a {@code SortOption}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given sortOption is invalid.
+     */
+    public static SortOption parseSortOption(String sortOption) throws ParseException {
+        requireNonNull(sortOption);
+        String trimmedOption = sortOption.trim();
+        if (!SortOption.isValidSortOption(trimmedOption)) {
+            throw new ParseException(SortOption.MESSAGE_CONSTRAINTS);
+        }
+        return new SortOption(trimmedOption);
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/SortOption.java
+++ b/src/main/java/seedu/address/logic/parser/SortOption.java
@@ -1,0 +1,67 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Contains valid sorting options for the list command.
+ */
+public class SortOption {
+    public static final String SORT_ALPHABETICAL = "alphabet";
+    // Add more sorting options if needed
+
+    public static final List<String> VALID_SORT_OPTIONS = Arrays.asList(
+            SORT_ALPHABETICAL
+            // Add other sorting options here
+    );
+
+    public static final String MESSAGE_CONSTRAINTS = "Invalid sort option: %s\nValid options are: "
+            + String.join(", ", VALID_SORT_OPTIONS);
+
+    private final String value;
+
+    /**
+     * Constructs a {@code SortOption}.
+     *
+     * @param option A valid sort option.
+     */
+    public SortOption(String option) {
+        requireNonNull(option);
+        value = option;
+    }
+
+    /**
+     * Returns true if a given string is a valid SortOption.
+     */
+    public static boolean isValidSortOption(String sortOption) {
+        sortOption = sortOption.toLowerCase();
+        return VALID_SORT_OPTIONS.contains(sortOption);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof SortOption)) {
+            return false;
+        }
+
+        SortOption otherSortOption = (SortOption) other;
+        return value.equals(otherSortOption.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/SortOption.java
+++ b/src/main/java/seedu/address/logic/parser/SortOption.java
@@ -17,7 +17,7 @@ public class SortOption {
             // Add other sorting options here
     );
 
-    public static final String MESSAGE_CONSTRAINTS = "Invalid sort option: %s\nValid options are: "
+    public static final String MESSAGE_CONSTRAINTS = "Invalid sort option.\nValid options are: "
             + String.join(", ", VALID_SORT_OPTIONS);
 
     private final String value;

--- a/src/main/java/seedu/address/logic/parser/SortOption.java
+++ b/src/main/java/seedu/address/logic/parser/SortOption.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,6 +30,7 @@ public class SortOption {
      */
     public SortOption(String option) {
         requireNonNull(option);
+        checkArgument(isValidSortOption(option), MESSAGE_CONSTRAINTS);
         value = option;
     }
 

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.parser.SortOption;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -41,8 +42,11 @@ public class ListCommandTest {
 
     @Test
     public void execute_withSortOption_showsNotImplementedMessage() {
-        // Create a ListCommand with a sort option (e.g., "alphabet")
-        ListCommand listCommandWithSort = new ListCommand("alphabet");
+        // Create a SortOption instance with "alphabet"
+        SortOption sortOption = new SortOption("alphabet");
+
+        // Create a ListCommand with the SortOption
+        ListCommand listCommandWithSort = new ListCommand(sortOption);
 
         // The expected outcome should be the "Sorting not yet implemented" message
         assertCommandSuccess(listCommandWithSort, model, ListCommand.MESSAGE_SORT_NOT_IMPLEMENTED, expectedModel);
@@ -56,12 +60,15 @@ public class ListCommandTest {
         assertEquals(listCommand1, listCommand2);
 
         // ListCommand with the same sortOption should be equal
-        ListCommand listCommandWithSort1 = new ListCommand("alphabet");
-        ListCommand listCommandWithSort2 = new ListCommand("alphabet");
+        SortOption sortOption1 = new SortOption("alphabet");
+        SortOption sortOption2 = new SortOption("alphabet");
+        ListCommand listCommandWithSort1 = new ListCommand(sortOption1);
+        ListCommand listCommandWithSort2 = new ListCommand(sortOption2);
         assertEquals(listCommandWithSort1, listCommandWithSort2);
 
         // ListCommand with different sortOptions should not be equal
-        ListCommand listCommandWithSort3 = new ListCommand("name");
+        SortOption sortOption3 = new SortOption("name"); // Assuming "name" is not a valid option but for test purposes
+        ListCommand listCommandWithSort3 = new ListCommand(sortOption3);
         assertNotEquals(listCommandWithSort1, listCommandWithSort3);
 
         // ListCommand with and without sortOption should not be equal

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -66,11 +66,6 @@ public class ListCommandTest {
         ListCommand listCommandWithSort2 = new ListCommand(sortOption2);
         assertEquals(listCommandWithSort1, listCommandWithSort2);
 
-        // ListCommand with different sortOptions should not be equal
-        SortOption sortOption3 = new SortOption("name"); // Assuming "name" is not a valid option but for test purposes
-        ListCommand listCommandWithSort3 = new ListCommand(sortOption3);
-        assertNotEquals(listCommandWithSort1, listCommandWithSort3);
-
         // ListCommand with and without sortOption should not be equal
         assertNotEquals(listCommand1, listCommandWithSort1);
     }

--- a/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
@@ -20,7 +20,8 @@ public class ListCommandParserTest {
 
     @Test
     public void parse_validSortOption_returnsListCommand() {
-        assertParseSuccess(parser, " s/alphabet", new ListCommand("alphabet"));
+        SortOption sortOption = new SortOption("alphabet");
+        assertParseSuccess(parser, " s/alphabet", new ListCommand(sortOption));
     }
 
     @Test
@@ -32,5 +33,11 @@ public class ListCommandParserTest {
     @Test
     public void parse_emptySortOption_throwsParseException() {
         assertParseFailure(parser, " s/", "Sort option cannot be empty.");
+    }
+
+    @Test
+    public void parse_invalidSortOption_throwsParseException() {
+        SortOption sortOption = new SortOption("alphabet");
+        assertParseFailure(parser, " s/name", SortOption.MESSAGE_CONSTRAINTS);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/SortOptionTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortOptionTest.java
@@ -1,0 +1,68 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contains unit tests for {@code SortOption}.
+ */
+public class SortOptionTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        // Null input should throw NullPointerException
+        assertThrows(NullPointerException.class, () -> new SortOption(null));
+    }
+
+    @Test
+    public void constructor_validOption_createsSortOption() {
+        // Valid sort option
+        SortOption sortOption = new SortOption("alphabet");
+        assertTrue(sortOption.toString().equals("alphabet"));
+    }
+
+    @Test
+    public void isValidSortOption_null_throwsNullPointerException() {
+        // Null input should throw NullPointerException
+        assertThrows(NullPointerException.class, () -> SortOption.isValidSortOption(null));
+    }
+
+    @Test
+    public void isValidSortOption_validOption_returnsTrue() {
+        // Valid sort options
+        assertTrue(SortOption.isValidSortOption("alphabet"));
+        assertTrue(SortOption.isValidSortOption("ALPHABET")); // Case-insensitive
+    }
+
+    @Test
+    public void isValidSortOption_invalidOption_returnsFalse() {
+        // Invalid sort options
+        assertFalse(SortOption.isValidSortOption("age")); // Not in VALID_SORT_OPTIONS
+        assertFalse(SortOption.isValidSortOption("name"));
+        assertFalse(SortOption.isValidSortOption(""));
+        assertFalse(SortOption.isValidSortOption(" "));
+    }
+
+    @Test
+    public void equals() {
+        SortOption sortOption = new SortOption("alphabet");
+
+        // same values -> returns true
+        assertTrue(sortOption.equals(new SortOption("alphabet")));
+
+        // same object -> returns true
+        assertTrue(sortOption.equals(sortOption));
+
+        // null -> returns false
+        assertFalse(sortOption.equals(null));
+
+        // different types -> returns false
+        assertFalse(sortOption.equals(5));
+
+        // different values -> returns false
+        assertFalse(sortOption.equals(new SortOption("age")));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/SortOptionTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortOptionTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -21,7 +22,13 @@ public class SortOptionTest {
     public void constructor_validOption_createsSortOption() {
         // Valid sort option
         SortOption sortOption = new SortOption("alphabet");
-        assertTrue(sortOption.toString().equals("alphabet"));
+        assertEquals("alphabet", sortOption.toString());
+    }
+
+    @Test
+    public void constructor_invalidOption_throwsIllegalArgumentException() {
+        String invalidOption = "NotSortOption";
+        assertThrows(IllegalArgumentException.class, () -> new SortOption(invalidOption));
     }
 
     @Test
@@ -47,6 +54,20 @@ public class SortOptionTest {
     }
 
     @Test
+    public void testHashCode() {
+        SortOption sortOption1 = new SortOption("alphabet");
+        SortOption sortOption2 = new SortOption("alphabet");
+
+        // Ensure that hashCode returns the same value consistently
+        int initialHashCode = sortOption1.hashCode();
+        assertEquals(initialHashCode, sortOption1.hashCode());
+        assertEquals(initialHashCode, sortOption1.hashCode());
+
+        // Ensure their hash codes are the same
+        assertEquals(sortOption1.hashCode(), sortOption2.hashCode());
+    }
+
+    @Test
     public void equals() {
         SortOption sortOption = new SortOption("alphabet");
 
@@ -62,7 +83,7 @@ public class SortOptionTest {
         // different types -> returns false
         assertFalse(sortOption.equals(5));
 
-        // different values -> returns false
-        assertFalse(sortOption.equals(new SortOption("age")));
+        // Currently can only create SortOption with alphabet.
+        // Add more cases to check SortOption are not equal when option is different
     }
 }


### PR DESCRIPTION
Any sort option entered was deemed as valid. The message, "sorting not yet implemented" would be displayed regardless of what sorting option was entered.

Add SortOption class and parseSortOption method in ParseUtil class to check for supported sort options. 
The message, "sorting not yet implemented" will only be displayed for valid sorting options (Only "alphabet" for now). Invalid sorting options will lead to the message: "Invalid sort option. Valid options are: " with the valid sort options being displayed. 

Close #74 