### PR TITLE
Add sorting functionality for list command

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -31,7 +31,7 @@ public interface Logic {
     ReadOnlyAddressBook getAddressBook();
 
     /** Returns an unmodifiable view of the filtered list of persons */
-    ObservableList<Person> getFilteredPersonList();
+    ObservableList<Person> getPersonList();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -67,8 +67,8 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObservableList<Person> getFilteredPersonList() {
-        return model.getFilteredPersonList();
+    public ObservableList<Person> getPersonList() {
+        return model.getPersonList();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -34,7 +34,7 @@ public class DeleteCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getPersonList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -70,7 +70,7 @@ public class EditCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -31,7 +31,7 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getPersonList().size()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.COMPARATOR_SORT_BY_NAME;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -19,7 +20,7 @@ public class ListCommand extends Command {
             + "Example: " + COMMAND_WORD + " s/alphabet";
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
-    public static final String MESSAGE_SORT_NOT_IMPLEMENTED = "Sorting not yet implemented.";
+    public static final String MESSAGE_SORT_SUCCESS = "Listed all persons sorted by %s";
 
     private final SortOption sortOption;
 
@@ -36,11 +37,16 @@ public class ListCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        if (sortOption != null) {
-            // For now, we just inform the user that sorting is not implemented
-            return new CommandResult(MESSAGE_SORT_NOT_IMPLEMENTED);
+        if (sortOption == null) {
+            model.clearPersonSort();
+            return new CommandResult(MESSAGE_SUCCESS);
         }
-        return new CommandResult(MESSAGE_SUCCESS);
+
+        switch (sortOption.toString()) {
+        case SortOption.SORT_NAME -> model.updatePersonListSort(COMPARATOR_SORT_BY_NAME);
+        default -> throw new CommandException("Unsupported sort option: " + sortOption);
+        }
+        return new CommandResult(String.format(MESSAGE_SORT_SUCCESS, sortOption));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT;
 import static seedu.address.model.Model.COMPARATOR_SORT_BY_NAME;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
@@ -16,8 +17,8 @@ public class ListCommand extends Command {
     public static final String COMMAND_WORD = "list";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all persons in the address book.\n"
-            + "Optional parameters: [s/SORT_OPTION]\n"
-            + "Example: " + COMMAND_WORD + " s/alphabet";
+            + "Parameters: " + "[" + PREFIX_SORT + "SORT_OPTION]\n"
+            + "Example: " + COMMAND_WORD + " s/name";
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
     public static final String MESSAGE_SORT_SUCCESS = "Listed all persons sorted by %s";

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT;
 
 import java.util.Optional;
@@ -21,6 +22,10 @@ public class ListCommandParser implements Parser<ListCommand> {
     public ListCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SORT);
+
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+        }
 
         // Ensure there are no duplicate sort prefixes
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_SORT);

--- a/src/main/java/seedu/address/logic/parser/SortOption.java
+++ b/src/main/java/seedu/address/logic/parser/SortOption.java
@@ -10,11 +10,11 @@ import java.util.List;
  * Contains valid sorting options for the list command.
  */
 public class SortOption {
-    public static final String SORT_ALPHABETICAL = "alphabet";
+    public static final String SORT_NAME = "name";
     // Add more sorting options if needed
 
     public static final List<String> VALID_SORT_OPTIONS = Arrays.asList(
-            SORT_ALPHABETICAL
+            SORT_NAME
             // Add other sorting options here
     );
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -13,6 +14,9 @@ import seedu.address.model.person.Person;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+
+    /** {@code Comparator} that sorts the list by name in alphabetical order */
+    Comparator<Person> COMPARATOR_SORT_BY_NAME = Comparator.comparing(person -> person.getName().toString());
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -76,12 +80,23 @@ public interface Model {
      */
     void setPerson(Person target, Person editedPerson);
 
-    /** Returns an unmodifiable view of the filtered person list */
-    ObservableList<Person> getFilteredPersonList();
+    /** Returns an unmodifiable view of the person list */
+    ObservableList<Person> getPersonList();
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Updates the sort order of the person list to the given {@code comparator}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updatePersonListSort(Comparator<Person> comparator);
+
+    /**
+     * Clears any sorting applied to the person list.
+     */
+    void clearPersonSort();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -114,11 +114,17 @@ public class ModelManager implements Model {
 
         addressBook.setPerson(target, editedPerson);
     }
+
     //=========== Person List Accessors ======================================================================
 
     /**
      * Returns an unmodifiable view of the list of {@code Person} backed by the internal list of
      * {@code versionedAddressBook}
+     *
+     * The returned list is both sorted and filtered based on the current comparator and filter predicate
+     * applied.
+     *
+     * @return a filtered and sorted list of persons.
      */
     @Override
     public ObservableList<Person> getPersonList() {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,11 +4,13 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
@@ -22,6 +24,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final SortedList<Person> sortedPersons;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -34,6 +37,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        sortedPersons = new SortedList<>(filteredPersons);
     }
 
     public ModelManager() {
@@ -110,22 +114,35 @@ public class ModelManager implements Model {
 
         addressBook.setPerson(target, editedPerson);
     }
-
-    //=========== Filtered Person List Accessors =============================================================
+    //=========== Person List Accessors ======================================================================
 
     /**
      * Returns an unmodifiable view of the list of {@code Person} backed by the internal list of
      * {@code versionedAddressBook}
      */
     @Override
-    public ObservableList<Person> getFilteredPersonList() {
-        return filteredPersons;
+    public ObservableList<Person> getPersonList() {
+        // sortedPersons observes changes in filteredPersons
+        return sortedPersons;
     }
+
+    //=========== Filtered Person List Accessors =============================================================
 
     @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    //=========== Sorted Person List Accessors =============================================================
+    @Override
+    public void updatePersonListSort(Comparator<Person> comparator) {
+        sortedPersons.setComparator(comparator);
+    }
+
+    @Override
+    public void clearPersonSort() {
+        sortedPersons.setComparator(null);
     }
 
     @Override
@@ -142,7 +159,8 @@ public class ModelManager implements Model {
         ModelManager otherModelManager = (ModelManager) other;
         return addressBook.equals(otherModelManager.addressBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
-                && filteredPersons.equals(otherModelManager.filteredPersons);
+                && filteredPersons.equals(otherModelManager.filteredPersons)
+                && sortedPersons.equals(otherModelManager.sortedPersons);
     }
 
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -110,7 +110,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        personListPanel = new PersonListPanel(logic.getPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -84,7 +84,7 @@ public class LogicManagerTest {
 
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredPersonList().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> logic.getPersonList().remove(0));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -83,7 +83,7 @@ public class LogicManagerTest {
     }
 
     @Test
-    public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
+    public void getPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> logic.getPersonList().remove(0));
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -149,13 +150,23 @@ public class AddCommandTest {
         }
 
         @Override
-        public ObservableList<Person> getFilteredPersonList() {
+        public ObservableList<Person> getPersonList() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updatePersonListSort(Comparator<Person> comparator) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void clearPersonSort() {
+
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -166,7 +166,7 @@ public class AddCommandTest {
 
         @Override
         public void clearPersonSort() {
-
+            throw new AssertionError("This method should not be called.");
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -105,24 +105,24 @@ public class CommandTestUtil {
         // we are unable to defensively copy the model for comparison later, so we can
         // only do so by copying its components.
         AddressBook expectedAddressBook = new AddressBook(actualModel.getAddressBook());
-        List<Person> expectedFilteredList = new ArrayList<>(actualModel.getFilteredPersonList());
+        List<Person> expectedFilteredList = new ArrayList<>(actualModel.getPersonList());
 
         assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel));
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
-        assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
+        assertEquals(expectedFilteredList, actualModel.getPersonList());
     }
     /**
      * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
      * {@code model}'s address book.
      */
     public static void showPersonAtIndex(Model model, Index targetIndex) {
-        assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());
+        assertTrue(targetIndex.getZeroBased() < model.getPersonList().size());
 
-        Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
+        Person person = model.getPersonList().get(targetIndex.getZeroBased());
         final String[] splitName = person.getName().fullName.split("\\s+");
         model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
-        assertEquals(1, model.getFilteredPersonList().size());
+        assertEquals(1, model.getPersonList().size());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -29,7 +29,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToDelete = model.getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
@@ -43,7 +43,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getPersonList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -53,7 +53,7 @@ public class DeleteCommandTest {
     public void execute_validIndexFilteredList_success() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToDelete = model.getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
@@ -115,6 +115,6 @@ public class DeleteCommandTest {
     private void showNoPerson(Model model) {
         model.updateFilteredPersonList(p -> false);
 
-        assertTrue(model.getFilteredPersonList().isEmpty());
+        assertTrue(model.getPersonList().isEmpty());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -44,15 +44,15 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.setPerson(model.getPersonList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
-        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
-        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+        Index indexLastPerson = Index.fromOneBased(model.getPersonList().size());
+        Person lastPerson = model.getPersonList().get(indexLastPerson.getZeroBased());
 
         PersonBuilder personInList = new PersonBuilder(lastPerson);
         Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
@@ -73,7 +73,7 @@ public class EditCommandTest {
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
-        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = model.getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
@@ -86,7 +86,7 @@ public class EditCommandTest {
     public void execute_filteredList_success() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
-        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personInFilteredList = model.getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
@@ -94,14 +94,14 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.setPerson(model.getPersonList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person firstPerson = model.getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
 
@@ -122,7 +122,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getPersonList().size() + 1);
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -61,7 +61,7 @@ public class FindCommandTest {
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+        assertEquals(Collections.emptyList(), model.getPersonList());
     }
 
     @Test
@@ -71,7 +71,7 @@ public class FindCommandTest {
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
+        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getPersonList());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -4,16 +4,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.model.Model.COMPARATOR_SORT_BY_NAME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.ObservableList;
 import seedu.address.logic.parser.SortOption;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -38,6 +45,27 @@ public class ListCommandTest {
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_validSortOption_success() {
+        SortOption sortOption = new SortOption(SortOption.SORT_NAME);
+        ListCommand listCommand = new ListCommand(sortOption);
+
+        // Prepare the expected sorted list
+        List<Person> expectedSortedList = new ArrayList<>(model.getAddressBook().getPersonList());
+        expectedSortedList.sort(COMPARATOR_SORT_BY_NAME);
+
+        // Update expectedModel to match the sorted state
+        expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        expectedModel.updatePersonListSort(COMPARATOR_SORT_BY_NAME);
+
+        assertCommandSuccess(listCommand, model,
+                String.format(ListCommand.MESSAGE_SORT_SUCCESS, sortOption), expectedModel);
+
+        // Check if list is sorted correctly
+        ObservableList<Person> actualList = model.getPersonList();
+        assertEquals(expectedSortedList, new ArrayList<>(actualList));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -41,18 +41,6 @@ public class ListCommandTest {
     }
 
     @Test
-    public void execute_withSortOption_showsNotImplementedMessage() {
-        // Create a SortOption instance with "alphabet"
-        SortOption sortOption = new SortOption("alphabet");
-
-        // Create a ListCommand with the SortOption
-        ListCommand listCommandWithSort = new ListCommand(sortOption);
-
-        // The expected outcome should be the "Sorting not yet implemented" message
-        assertCommandSuccess(listCommandWithSort, model, ListCommand.MESSAGE_SORT_NOT_IMPLEMENTED, expectedModel);
-    }
-
-    @Test
     public void equals() {
         // Same ListCommand without sortOption should be equal
         ListCommand listCommand1 = new ListCommand();
@@ -60,8 +48,8 @@ public class ListCommandTest {
         assertEquals(listCommand1, listCommand2);
 
         // ListCommand with the same sortOption should be equal
-        SortOption sortOption1 = new SortOption("alphabet");
-        SortOption sortOption2 = new SortOption("alphabet");
+        SortOption sortOption1 = new SortOption("name");
+        SortOption sortOption2 = new SortOption("name");
         ListCommand listCommandWithSort1 = new ListCommand(sortOption1);
         ListCommand listCommandWithSort2 = new ListCommand(sortOption2);
         assertEquals(listCommandWithSort1, listCommandWithSort2);

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -85,7 +85,12 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_unrecognisedExtraInput_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE), ()
+                -> parser.parseCommand("list extraInput"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
@@ -20,14 +20,14 @@ public class ListCommandParserTest {
 
     @Test
     public void parse_validSortOption_returnsListCommand() {
-        SortOption sortOption = new SortOption("alphabet");
-        assertParseSuccess(parser, " s/alphabet", new ListCommand(sortOption));
+        SortOption sortOption = new SortOption("name");
+        assertParseSuccess(parser, " s/name", new ListCommand(sortOption));
     }
 
     @Test
     public void parse_multipleValidSortOptions_throwsParseException() {
         String expectedMessage = Messages.getErrorMessageForDuplicatePrefixes(PREFIX_SORT);
-        assertParseFailure(parser, " s/alphabet s/age", expectedMessage);
+        assertParseFailure(parser, " s/name s/age", expectedMessage);
     }
 
     @Test
@@ -37,7 +37,6 @@ public class ListCommandParserTest {
 
     @Test
     public void parse_invalidSortOption_throwsParseException() {
-        SortOption sortOption = new SortOption("alphabet");
-        assertParseFailure(parser, " s/name", SortOption.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " s/Invalid", SortOption.MESSAGE_CONSTRAINTS);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/SortOptionTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortOptionTest.java
@@ -21,8 +21,8 @@ public class SortOptionTest {
     @Test
     public void constructor_validOption_createsSortOption() {
         // Valid sort option
-        SortOption sortOption = new SortOption("alphabet");
-        assertEquals("alphabet", sortOption.toString());
+        SortOption sortOption = new SortOption("name");
+        assertEquals("name", sortOption.toString());
     }
 
     @Test
@@ -40,23 +40,22 @@ public class SortOptionTest {
     @Test
     public void isValidSortOption_validOption_returnsTrue() {
         // Valid sort options
-        assertTrue(SortOption.isValidSortOption("alphabet"));
-        assertTrue(SortOption.isValidSortOption("ALPHABET")); // Case-insensitive
+        assertTrue(SortOption.isValidSortOption("name"));
+        assertTrue(SortOption.isValidSortOption("name")); // Case-insensitive
     }
 
     @Test
     public void isValidSortOption_invalidOption_returnsFalse() {
         // Invalid sort options
         assertFalse(SortOption.isValidSortOption("age")); // Not in VALID_SORT_OPTIONS
-        assertFalse(SortOption.isValidSortOption("name"));
         assertFalse(SortOption.isValidSortOption(""));
         assertFalse(SortOption.isValidSortOption(" "));
     }
 
     @Test
     public void testHashCode() {
-        SortOption sortOption1 = new SortOption("alphabet");
-        SortOption sortOption2 = new SortOption("alphabet");
+        SortOption sortOption1 = new SortOption("name");
+        SortOption sortOption2 = new SortOption("name");
 
         // Ensure that hashCode returns the same value consistently
         int initialHashCode = sortOption1.hashCode();
@@ -69,10 +68,10 @@ public class SortOptionTest {
 
     @Test
     public void equals() {
-        SortOption sortOption = new SortOption("alphabet");
+        SortOption sortOption = new SortOption("name");
 
         // same values -> returns true
-        assertTrue(sortOption.equals(new SortOption("alphabet")));
+        assertTrue(sortOption.equals(new SortOption("name")));
 
         // same object -> returns true
         assertTrue(sortOption.equals(sortOption));
@@ -83,7 +82,7 @@ public class SortOptionTest {
         // different types -> returns false
         assertFalse(sortOption.equals(5));
 
-        // Currently can only create SortOption with alphabet.
+        // Currently can only create SortOption with name.
         // Add more cases to check SortOption are not equal when option is different
     }
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -89,7 +89,7 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
+    public void getPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getPersonList().remove(0));
     }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -90,7 +90,7 @@ public class ModelManagerTest {
 
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getPersonList().remove(0));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -36,20 +36,20 @@ public class TestUtil {
      * Returns the middle index of the person in the {@code model}'s person list.
      */
     public static Index getMidIndex(Model model) {
-        return Index.fromOneBased(model.getFilteredPersonList().size() / 2);
+        return Index.fromOneBased(model.getPersonList().size() / 2);
     }
 
     /**
      * Returns the last index of the person in the {@code model}'s person list.
      */
     public static Index getLastIndex(Model model) {
-        return Index.fromOneBased(model.getFilteredPersonList().size());
+        return Index.fromOneBased(model.getPersonList().size());
     }
 
     /**
      * Returns the person in the {@code model}'s person list at {@code index}.
      */
     public static Person getPerson(Model model, Index index) {
-        return model.getFilteredPersonList().get(index.getZeroBased());
+        return model.getPersonList().get(index.getZeroBased());
     }
 }


### PR DESCRIPTION
Fixes #66 

### Problem:
`FilteredList` does not support sorting functionality.

### Solution:
- Wrap the existing `FilteredList` in a `SortedList` to add sorting capabilities.
- Rename `getFilteredPersonList()` to `getPersonList()` to indicate the list may be both filtered and sorted.
- Update `getPersonList()` to return the `SortedList`, which observes changes in the underlying `FilteredList` and updates dynamically.
- Add methods to update the sort comparator, allowing sorting based on various criteria (e.g. name).
- Rename the sorting parameter `alphabet` to `name` for clarity.

### Notes:
- Future calls to the `list` command after sorting will return the sorted list until the sorting parameter is cleared.
