### PR TITLE
Create new Sort command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,12 +1,8 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT;
-import static seedu.address.model.Model.COMPARATOR_SORT_BY_NAME;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.parser.SortOption;
 import seedu.address.model.Model;
 
 /**
@@ -16,53 +12,13 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all persons in the address book.\n"
-            + "Parameters: " + "[" + PREFIX_SORT + "SORT_OPTION]\n"
-            + "Example: " + COMMAND_WORD + " s/name";
-
     public static final String MESSAGE_SUCCESS = "Listed all persons";
-    public static final String MESSAGE_SORT_SUCCESS = "Listed all persons sorted by %s";
 
-    private final SortOption sortOption;
-
-    public ListCommand() {
-        this.sortOption = null;
-    }
-
-    public ListCommand(SortOption sortOption) {
-        this.sortOption = sortOption;
-    }
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-
-        if (sortOption == null) {
-            model.clearPersonSort();
-            return new CommandResult(MESSAGE_SUCCESS);
-        }
-
-        switch (sortOption.toString()) {
-        case SortOption.SORT_NAME -> model.updatePersonListSort(COMPARATOR_SORT_BY_NAME);
-        default -> throw new CommandException("Unsupported sort option: " + sortOption);
-        }
-        return new CommandResult(String.format(MESSAGE_SORT_SUCCESS, sortOption));
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        // If both commands have the same sortOption, they are considered equal
-        if (other == this) {
-            return true;
-        }
-
-        if (!(other instanceof ListCommand)) {
-            return false;
-        }
-
-        ListCommand otherCommand = (ListCommand) other;
-        return (sortOption == null && otherCommand.sortOption == null)
-                || (sortOption != null && sortOption.equals(otherCommand.sortOption));
+        return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -1,0 +1,67 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT;
+import static seedu.address.model.Model.COMPARATOR_SORT_BY_NAME;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.SortOption;
+import seedu.address.model.Model;
+
+/**
+ * Sorts the person list based on the specified option.
+ */
+public class SortCommand extends Command {
+
+    public static final String COMMAND_WORD = "sort";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts the person list.\n"
+            + "If no sort option is provided, the list is restored to its original order (i.e., order of addition).\n"
+            + "Parameters: " + "[" + PREFIX_SORT + "SORT_OPTION]\n"
+            + "Example: " + COMMAND_WORD + " s/name";
+
+    public static final String MESSAGE_DEFAULT_SUCCESS = "Sorted by default order";
+    public static final String MESSAGE_SORT_SUCCESS = "Sorted by %s";
+
+    private final SortOption sortOption;
+
+    public SortCommand() {
+        this.sortOption = null;
+    }
+
+    public SortCommand(SortOption sortOption) {
+        this.sortOption = sortOption;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (sortOption == null) {
+            model.clearPersonSort();
+            return new CommandResult(MESSAGE_DEFAULT_SUCCESS);
+        }
+
+        switch (sortOption.toString()) {
+        case SortOption.SORT_NAME -> model.updatePersonListSort(COMPARATOR_SORT_BY_NAME);
+        default -> throw new CommandException("Unsupported sort option: " + sortOption);
+        }
+        return new CommandResult(String.format(MESSAGE_SORT_SUCCESS, sortOption));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // If both commands have the same sortOption, they are considered equal
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof SortCommand)) {
+            return false;
+        }
+
+        SortCommand otherCommand = (SortCommand) other;
+        return (sortOption == null && otherCommand.sortOption == null)
+                || (sortOption != null && sortOption.equals(otherCommand.sortOption));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -22,6 +22,7 @@ public class SortCommand extends Command {
 
     public static final String MESSAGE_DEFAULT_SUCCESS = "Sorted by default order";
     public static final String MESSAGE_SORT_SUCCESS = "Sorted by %s";
+    public static final String MESSAGE_UNSUPPORTED_SORT_OPTION = "Unsupported sort option: %s";
 
     private final SortOption sortOption;
 
@@ -43,8 +44,13 @@ public class SortCommand extends Command {
         }
 
         switch (sortOption.toString()) {
-        case SortOption.SORT_NAME -> model.updatePersonListSort(COMPARATOR_SORT_BY_NAME);
-        default -> throw new CommandException("Unsupported sort option: " + sortOption);
+        case SortOption.SORT_NAME:
+            model.updatePersonListSort(COMPARATOR_SORT_BY_NAME);
+            break;
+        default:
+            // Defensive programming: This should not happen as SortOption validates input,
+            // but we include this to catch any unexpected cases due to future changes.
+            throw new CommandException(String.format(MESSAGE_UNSUPPORTED_SORT_OPTION, sortOption));
         }
         return new CommandResult(String.format(MESSAGE_SORT_SUCCESS, sortOption));
     }
@@ -64,4 +70,6 @@ public class SortCommand extends Command {
         return (sortOption == null && otherCommand.sortOption == null)
                 || (sortOption != null && sortOption.equals(otherCommand.sortOption));
     }
+
+
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SearchCommand;
 import seedu.address.logic.commands.SetVolunteerHoursCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.group.CreateGroupCommand;
 import seedu.address.logic.commands.group.DeleteGroupCommand;
 import seedu.address.logic.commands.group.ViewGroupCommand;
@@ -76,7 +77,7 @@ public class AddressBookParser {
             return new SearchCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommandParser().parse(arguments);
+            return new ListCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
@@ -95,6 +96,9 @@ public class AddressBookParser {
 
         case ViewGroupCommand.COMMAND_WORD:
             return new ViewGroupCommandParser().parse(arguments);
+
+        case SortCommand.COMMAND_WORD:
+            return new SortCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -6,25 +6,21 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT;
 
 import java.util.Optional;
 
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new ListCommand object
+ * Parses input arguments and creates a new SortCommand object.
  */
-public class ListCommandParser implements Parser<ListCommand> {
+public class SortCommandParser implements Parser<SortCommand> {
 
-    /**
-     * Parses the given {@code String} of arguments in the context of the ListCommand
-     * and returns a ListCommand object for execution.
-     * @throws ParseException if the user input does not conform to the expected format
-     */
-    public ListCommand parse(String args) throws ParseException {
+    @Override
+    public SortCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SORT);
 
         if (!argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
         }
 
         // Ensure there are no duplicate sort prefixes
@@ -34,7 +30,7 @@ public class ListCommandParser implements Parser<ListCommand> {
 
         if (sortOption.isEmpty()) {
             // No sort option
-            return new ListCommand();
+            return new SortCommand();
         }
 
         String sortOptionValue = sortOption.get().trim();
@@ -45,6 +41,6 @@ public class ListCommandParser implements Parser<ListCommand> {
 
         // Ensure sort option is supported
         SortOption validSortOption = ParserUtil.parseSortOption(sortOptionValue);
-        return new ListCommand(validSortOption);
+        return new SortCommand(validSortOption);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT;
+import static seedu.address.logic.parser.SortOption.MESSAGE_EMPTY_SORT_OPTION;
 
 import java.util.Optional;
 
@@ -36,7 +37,7 @@ public class SortCommandParser implements Parser<SortCommand> {
         String sortOptionValue = sortOption.get().trim();
 
         if (sortOptionValue.isEmpty()) {
-            throw new ParseException("Sort option cannot be empty.");
+            throw new ParseException(MESSAGE_EMPTY_SORT_OPTION);
         }
 
         // Ensure sort option is supported

--- a/src/main/java/seedu/address/logic/parser/SortOption.java
+++ b/src/main/java/seedu/address/logic/parser/SortOption.java
@@ -21,6 +21,8 @@ public class SortOption {
     public static final String MESSAGE_CONSTRAINTS = "Invalid sort option.\nValid options are: "
             + String.join(", ", VALID_SORT_OPTIONS);
 
+    public static final String MESSAGE_EMPTY_SORT_OPTION = "Sort option cannot be empty.";
+
     private final String value;
 
     /**

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -1,26 +1,16 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.model.Model.COMPARATOR_SORT_BY_NAME;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.logic.parser.SortOption;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.Person;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -45,44 +35,5 @@ public class ListCommandTest {
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
-    }
-
-    @Test
-    public void execute_validSortOption_success() {
-        SortOption sortOption = new SortOption(SortOption.SORT_NAME);
-        ListCommand listCommand = new ListCommand(sortOption);
-
-        // Prepare the expected sorted list
-        List<Person> expectedSortedList = new ArrayList<>(model.getAddressBook().getPersonList());
-        expectedSortedList.sort(COMPARATOR_SORT_BY_NAME);
-
-        // Update expectedModel to match the sorted state
-        expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        expectedModel.updatePersonListSort(COMPARATOR_SORT_BY_NAME);
-
-        assertCommandSuccess(listCommand, model,
-                String.format(ListCommand.MESSAGE_SORT_SUCCESS, sortOption), expectedModel);
-
-        // Check if list is sorted correctly
-        ObservableList<Person> actualList = model.getPersonList();
-        assertEquals(expectedSortedList, new ArrayList<>(actualList));
-    }
-
-    @Test
-    public void equals() {
-        // Same ListCommand without sortOption should be equal
-        ListCommand listCommand1 = new ListCommand();
-        ListCommand listCommand2 = new ListCommand();
-        assertEquals(listCommand1, listCommand2);
-
-        // ListCommand with the same sortOption should be equal
-        SortOption sortOption1 = new SortOption("name");
-        SortOption sortOption2 = new SortOption("name");
-        ListCommand listCommandWithSort1 = new ListCommand(sortOption1);
-        ListCommand listCommandWithSort2 = new ListCommand(sortOption2);
-        assertEquals(listCommandWithSort1, listCommandWithSort2);
-
-        // ListCommand with and without sortOption should not be equal
-        assertNotEquals(listCommand1, listCommandWithSort1);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -41,10 +41,9 @@ public class SortCommandTest {
     public void execute_invalidSortOption_throwsCommandException() {
         InvalidSortOptionStub sortOption = new InvalidSortOptionStub("Invalid");
         SortCommand sortCommand = new SortCommand(sortOption);
+        String expectedMessage = String.format(SortCommand.MESSAGE_UNSUPPORTED_SORT_OPTION, sortOption);
 
-        assertThrows(CommandException.class,
-                String.format(SortCommand.MESSAGE_UNSUPPORTED_SORT_OPTION, sortOption),
-                () -> sortCommand.execute(model));
+        assertThrows(CommandException.class, expectedMessage, () -> sortCommand.execute(model));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -87,6 +87,11 @@ public class SortCommandTest {
 
     @Test
     public void equals() {
+        SortCommand sortCommand1 = new SortCommand();
+        SortCommand sortCommand2 = new SortCommand();
+
+        assertEquals(sortCommand1, sortCommand2);
+
         SortOption sortOptionName = new SortOption(SortOption.SORT_NAME);
         SortCommand sortByNameCommand1 = new SortCommand(sortOptionName);
         SortCommand sortByNameCommand2 = new SortCommand(sortOptionName);

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.SortCommand.MESSAGE_SORT_SUCCESS;
 import static seedu.address.model.Model.COMPARATOR_SORT_BY_NAME;
@@ -53,5 +54,42 @@ public class SortCommandTest {
         // Check if list is sorted correctly
         ObservableList<Person> actualList = model.getPersonList();
         assertEquals(expectedSortedList, new ArrayList<>(actualList));
+    }
+
+    @Test
+    public void execute_nullSortOption_resetsToDefaultOrder() {
+        SortCommand sortCommand = new SortCommand(null); // Passing null instead of SortOption
+
+        // Prepare the expected default list (insertion order)
+        List<Person> expectedDefaultList = new ArrayList<>(model.getAddressBook().getPersonList());
+
+        // Update expectedModel to match the default state
+        expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        expectedModel.clearPersonSort(); // Reset sorting in the expected model
+
+        assertCommandSuccess(sortCommand, model, SortCommand.MESSAGE_DEFAULT_SUCCESS, expectedModel);
+
+        // Check if list is reset to default order (insertion order)
+        ObservableList<Person> actualList = model.getPersonList();
+        assertEquals(expectedDefaultList, new ArrayList<>(actualList));
+    }
+
+    @Test
+    public void equals() {
+        SortOption sortOptionName = new SortOption(SortOption.SORT_NAME);
+        SortCommand sortByNameCommand1 = new SortCommand(sortOptionName);
+        SortCommand sortByNameCommand2 = new SortCommand(sortOptionName);
+
+        // Same object -> returns true
+        assertEquals(sortByNameCommand1, sortByNameCommand1);
+
+        // Same sort option -> returns true
+        assertEquals(sortByNameCommand1, sortByNameCommand2);
+
+        // Null -> returns false
+        assertNotEquals(sortByNameCommand1, null);
+
+        // Different types -> returns false
+        assertNotEquals(sortByNameCommand1, new ListCommand());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.SortCommand.MESSAGE_SORT_SUCCESS;
+import static seedu.address.model.Model.COMPARATOR_SORT_BY_NAME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
+import seedu.address.logic.parser.SortOption;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for SortCommand.
+ */
+public class SortCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_validSortOption_success() {
+        SortOption sortOption = new SortOption(SortOption.SORT_NAME);
+        SortCommand sortCommand = new SortCommand(sortOption);
+
+        // Prepare the expected sorted list
+        List<Person> expectedSortedList = new ArrayList<>(model.getAddressBook().getPersonList());
+        expectedSortedList.sort(COMPARATOR_SORT_BY_NAME);
+
+        // Update expectedModel to match the sorted state
+        expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        expectedModel.updatePersonListSort(COMPARATOR_SORT_BY_NAME);
+
+        assertCommandSuccess(sortCommand, model,
+                String.format(MESSAGE_SORT_SUCCESS, sortOption), expectedModel);
+
+        // Check if list is sorted correctly
+        ObservableList<Person> actualList = model.getPersonList();
+        assertEquals(expectedSortedList, new ArrayList<>(actualList));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.SortCommand.MESSAGE_SORT_SUCCESS;
 import static seedu.address.model.Model.COMPARATOR_SORT_BY_NAME;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.ArrayList;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.SortOption;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -33,6 +35,16 @@ public class SortCommandTest {
     public void setUp() {
         model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_invalidSortOption_throwsCommandException() {
+        InvalidSortOptionStub sortOption = new InvalidSortOptionStub("Invalid");
+        SortCommand sortCommand = new SortCommand(sortOption);
+
+        assertThrows(CommandException.class,
+                String.format(SortCommand.MESSAGE_UNSUPPORTED_SORT_OPTION, sortOption),
+                () -> sortCommand.execute(model));
     }
 
     @Test
@@ -91,5 +103,23 @@ public class SortCommandTest {
 
         // Different types -> returns false
         assertNotEquals(sortByNameCommand1, new ListCommand());
+    }
+
+    /**
+     * A SortOption stub that allows for invalid sort options.
+     */
+    private class InvalidSortOptionStub extends SortOption {
+
+        private final String value;
+
+        public InvalidSortOptionStub(String invalidOption) {
+            super(SORT_NAME); // Call super with a valid option to pass validation
+            this.value = invalidOption; // Set the invalid value directly
+        }
+
+        @Override
+        public String toString() {
+            return value; // Return the invalid option
+        }
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -85,12 +85,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-    }
-
-    @Test
-    public void parseCommand_unrecognisedExtraInput_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE), ()
-                -> parser.parseCommand("list extraInput"));
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -22,6 +22,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SearchCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -86,6 +87,18 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_sort() throws Exception {
+        SortOption sortOption = new SortOption(SortOption.SORT_NAME);
+        SortCommand command = (SortCommand) parser.parseCommand(
+                SortCommand.COMMAND_WORD + " s/" + SortOption.SORT_NAME);
+        assertEquals(new SortCommand(sortOption), command);
+
+        // Test for no sort option (default behavior)
+        command = (SortCommand) parser.parseCommand(SortCommand.COMMAND_WORD);
+        assertEquals(new SortCommand(), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -7,21 +7,21 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.SortCommand;
 
-public class ListCommandParserTest {
+public class SortCommandParserTest {
 
-    private ListCommandParser parser = new ListCommandParser();
+    SortCommandParser parser = new SortCommandParser();
 
     @Test
     public void parse_noArgs_returnsListCommand() {
-        assertParseSuccess(parser, "", new ListCommand());
+        assertParseSuccess(parser, "", new SortCommand());
     }
 
     @Test
     public void parse_validSortOption_returnsListCommand() {
         SortOption sortOption = new SortOption("name");
-        assertParseSuccess(parser, " s/name", new ListCommand(sortOption));
+        assertParseSuccess(parser, " s/name", new SortCommand(sortOption));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,8 +1,10 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.SortOption.MESSAGE_EMPTY_SORT_OPTION;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,14 +16,20 @@ public class SortCommandParserTest {
     SortCommandParser parser = new SortCommandParser();
 
     @Test
-    public void parse_noArgs_returnsListCommand() {
+    public void parse_noArgs_returnsSortCommand() {
         assertParseSuccess(parser, "", new SortCommand());
     }
 
     @Test
-    public void parse_validSortOption_returnsListCommand() {
+    public void parse_validSortOption_returnsSortCommand() {
         SortOption sortOption = new SortOption("name");
         assertParseSuccess(parser, " s/name", new SortCommand(sortOption));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, " invalid", expectedMessage);
     }
 
     @Test
@@ -32,7 +40,7 @@ public class SortCommandParserTest {
 
     @Test
     public void parse_emptySortOption_throwsParseException() {
-        assertParseFailure(parser, " s/", "Sort option cannot be empty.");
+        assertParseFailure(parser, " s/", MESSAGE_EMPTY_SORT_OPTION);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -13,7 +13,7 @@ import seedu.address.logic.commands.SortCommand;
 
 public class SortCommandParserTest {
 
-    SortCommandParser parser = new SortCommandParser();
+    private SortCommandParser parser = new SortCommandParser();
 
     @Test
     public void parse_noArgs_returnsSortCommand() {


### PR DESCRIPTION
Fixes #118 

List and sort functionality are combined.

Separating them allows for sort to be utilised after any other command.

Let's
* Create SortCommand and SortCommandParser class
* Remove SortOption from ListCommand
* Update ListCommand to ignore any preamble or extra parameters