### PR TITLE
Improve Role-Class Mapping and Type-Safe RoleComparator

### DIFF
--- a/src/main/java/seedu/address/logic/parser/SortOption.java
+++ b/src/main/java/seedu/address/logic/parser/SortOption.java
@@ -58,7 +58,7 @@ public enum SortOption {
      * Constructs a {@code SortOption}.
      *
      * @param value A valid sort option.
-     * @param role A valid Role
+     * @param role A valid Role associated to the sort option
      */
     SortOption(String value, Role role) {
         this.value = value;
@@ -66,14 +66,14 @@ public enum SortOption {
     }
 
     /*
-     * Returns the role associated to the enum as a string
+     * Returns the Role associated to the sort option as a string
      */
     public String getRoleAsString() {
         return role.toLowerCase();
     }
 
     /*
-     * Returns the class related to the enum
+     * Returns the class related to the sort option
      */
     public Class<? extends Person> getRelatedClass() {
         return role.getRelatedClass();

--- a/src/main/java/seedu/address/logic/parser/SortOption.java
+++ b/src/main/java/seedu/address/logic/parser/SortOption.java
@@ -20,58 +20,28 @@ import seedu.address.model.person.comparators.RoleComparator;
  * Contains valid sorting options for the sort command.
  */
 public enum SortOption {
-    NAME("name") {
+    NAME("name", Role.PERSON) {
         @Override
         public Comparator<Person> getComparator() {
             return new NameComparator();
         }
     },
-    HOURS("hours") {
+    HOURS("hours", Role.VOLUNTEER) {
         @Override
         public Comparator<Person> getComparator() {
             return new RoleComparator<>(Volunteer.class);
         }
-
-        @Override
-        public String getRoleAsString() {
-            return Role.VOLUNTEER.toLowerCase();
-        }
-
-        @Override
-        public Class<? extends Person> getRelatedClass() {
-            return Volunteer.class;
-        }
     },
-    DONATION("donations") {
+    DONATION("donations", Role.DONOR) {
         @Override
         public Comparator<Person> getComparator() {
             return new RoleComparator<>(Donor.class);
         }
-
-        @Override
-        public String getRoleAsString() {
-            return Role.DONOR.toLowerCase();
-        }
-
-        @Override
-        public Class<? extends Person> getRelatedClass() {
-            return Donor.class;
-        }
     },
-    PARTNERSHIP_END_DATE("end_date") {
+    PARTNERSHIP_END_DATE("end_date", Role.PARTNER) {
         @Override
         public Comparator<Person> getComparator() {
             return new RoleComparator<>(Partner.class);
-        }
-
-        @Override
-        public String getRoleAsString() {
-            return Role.PARTNER.toLowerCase();
-        }
-
-        @Override
-        public Class<? extends Person> getRelatedClass() {
-            return Partner.class;
         }
     };
     // Add more sorting options here if needed
@@ -83,17 +53,16 @@ public enum SortOption {
 
     private final String value;
     private final Role role;
-    private final Class<? extends Person> relatedClass;
 
     /**
      * Constructs a {@code SortOption}.
      *
      * @param value A valid sort option.
+     * @param role A valid Role
      */
-    SortOption(String value) {
+    SortOption(String value, Role role) {
         this.value = value;
-        role = Role.PERSON;
-        relatedClass = Person.class;
+        this.role = role;
     }
 
     /*
@@ -107,7 +76,7 @@ public enum SortOption {
      * Returns the class related to the enum
      */
     public Class<? extends Person> getRelatedClass() {
-        return relatedClass;
+        return role.getRelatedClass();
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/SortOption.java
+++ b/src/main/java/seedu/address/logic/parser/SortOption.java
@@ -69,7 +69,7 @@ public enum SortOption {
      * Returns the Role associated to the sort option as a string
      */
     public String getRoleAsString() {
-        return role.toLowerCase();
+        return role.toLowerCaseString();
     }
 
     /*

--- a/src/main/java/seedu/address/model/person/Role.java
+++ b/src/main/java/seedu/address/model/person/Role.java
@@ -5,13 +5,25 @@ package seedu.address.model.person;
  * Provides utility methods for converting a string into a Role and for validating if a string is a valid Role.
  */
 public enum Role {
-    VOLUNTEER,
-    DONOR,
-    PARTNER,
-    PERSON;
+    VOLUNTEER(Volunteer.class),
+    DONOR(Donor.class),
+    PARTNER(Partner.class),
+    PERSON(Person.class);
 
     public static final String MESSAGE_CONSTRAINTS =
             "Invalid role. Valid roles are: Volunteer, Donor, Partner, Person..";
+
+    private final Class<? extends Person> relatedClass;
+
+    /**
+     * Constructs a {@code Role}.
+     *
+     * @param relatedClass  The class associated with the role.
+     */
+    Role(Class<? extends Person> relatedClass) {
+        this.relatedClass = relatedClass;
+    }
+
     /**
      * Returns the Role corresponding to the given string.
      * Throws an IllegalArgumentException if no matching Role is found.
@@ -52,5 +64,14 @@ public enum Role {
      */
     public String toLowerCase() {
         return name().toLowerCase();
+    }
+
+    /**
+     * Returns the class related to this role.
+     *
+     * @return The related class.
+     */
+    public Class<? extends Person> getRelatedClass() {
+        return relatedClass;
     }
 }

--- a/src/main/java/seedu/address/model/person/Role.java
+++ b/src/main/java/seedu/address/model/person/Role.java
@@ -62,8 +62,8 @@ public enum Role {
      *
      * @return The name of the role in lowercase.
      */
-    public String toLowerCase() {
-        return name().toLowerCase();
+    public String toLowerCaseString() {
+        return toString().toLowerCase();
     }
 
     /**


### PR DESCRIPTION
Closes #188 

This PR introduces two key updates:

1. Update `Role` to be tied directly to its corresponding class type
   - The related class of a role can be accessed using methods like `Role.PARTNER.getRelatedClass()`
2. `SortOption` requires the explicit class type when creating a `RoleComparator` 
   - While `getRelatedClass()` remains available in Role, it returns a `Class<? extends Person>`, which is not compatible with the generic type required for `RoleComparator`.
   - Although adapting `RoleComparator` to use `getRelatedClass()` could simplify certain operations, this would involve unchecked type casting. 
   - Given the limited number of classes extending `Person`, It was determined that prioritising type safety and the benefits of generics outweighs the flexibility gained from using `getRelatedClass`
