### PR TITLE
Add GroupCard and GroupListPanel

### DIFF
--- a/src/main/java/seedu/address/ui/GroupCard.java
+++ b/src/main/java/seedu/address/ui/GroupCard.java
@@ -1,0 +1,54 @@
+package seedu.address.ui;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.address.model.person.Group;
+import seedu.address.model.person.Person;
+
+/**
+ * A UI component that displays information of a {@code Group}.
+ */
+public class GroupCard extends UiPart<Region> {
+
+    private static final String FXML = "GroupListCard.fxml";
+
+    public final Group group;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label groupName;
+    @FXML
+    private Label id;
+
+    @FXML
+    private FlowPane membersPane; // A FlowPane to display members
+
+    /**
+     * Creates a {@code GroupCard} with the given {@code Group} and index to display.
+     */
+    public GroupCard(Group group, int displayedIndex) {
+        super(FXML);
+        this.group = group;
+        id.setText(displayedIndex + ". ");
+        groupName.setText(group.getName());
+
+        // Retrieve the first 3 members of the group
+        List<Person> firstThreeMembers = group.asUnmodifiableObservableList().stream()
+                .limit(3)
+                .collect(Collectors.toList());
+
+        // Display each member in the FlowPane
+        firstThreeMembers.forEach(member -> {
+            Label memberLabel = new Label(member.getName().fullName);
+            membersPane.getChildren().add(memberLabel);
+        });
+    }
+}

--- a/src/main/java/seedu/address/ui/GroupCard.java
+++ b/src/main/java/seedu/address/ui/GroupCard.java
@@ -1,6 +1,5 @@
 package seedu.address.ui;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,7 +26,6 @@ public class GroupCard extends UiPart<Region> {
     private Label groupName;
     @FXML
     private Label id;
-
     @FXML
     private FlowPane membersPane; // A FlowPane to display members
 
@@ -40,15 +38,23 @@ public class GroupCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         groupName.setText(group.getName());
 
-        // Retrieve the first 3 members of the group
-        List<Person> firstThreeMembers = group.asUnmodifiableObservableList().stream()
+        // Retrieve the list of members in the group
+        List<Person> members = group.asUnmodifiableObservableList();
+
+        // Display the first 3 members in the FlowPane
+        List<Person> firstThreeMembers = members.stream()
                 .limit(3)
                 .collect(Collectors.toList());
 
-        // Display each member in the FlowPane
         firstThreeMembers.forEach(member -> {
             Label memberLabel = new Label(member.getName().fullName);
             membersPane.getChildren().add(memberLabel);
         });
+
+        // If there are more than 3 members, add a "..." at the back
+        if (members.size() > 3) {
+            Label moreLabel = new Label("...");
+            membersPane.getChildren().add(moreLabel);
+        }
     }
 }

--- a/src/main/java/seedu/address/ui/GroupListPanel.java
+++ b/src/main/java/seedu/address/ui/GroupListPanel.java
@@ -1,0 +1,48 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.person.Group;
+
+/**
+ * Panel containing the list of groups.
+ */
+public class GroupListPanel extends UiPart<Region> {
+    private static final String FXML = "GroupListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(GroupListPanel.class);
+
+    @FXML
+    private ListView<Group> groupListView;
+
+    /**
+     * Creates a {@code GroupListPanel} with the given {@code ObservableList}.
+     */
+    public GroupListPanel(ObservableList<Group> groupList) {
+        super(FXML);
+        groupListView.setItems(groupList);
+        groupListView.setCellFactory(listView -> new GroupListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Group} using a {@code GroupCard}.
+     */
+    class GroupListViewCell extends ListCell<Group> {
+        @Override
+        protected void updateItem(Group group, boolean empty) {
+            super.updateItem(group, empty);
+
+            if (empty || group == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new GroupCard(group, getIndex() + 1).getRoot());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #210 

Created a GroupCard class where upon the command `listGroups` it will be shown in the same manner as Persons. 
Will show all the group's name, and up to 3 members for each group. (if there are more than 3 members, will end off with '...') 

These UI classes have yet to been integrated into the system, will be done in future PR