### PR TITLE
Add search contactnumber feature

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -181,7 +181,7 @@ Example: `setHours 2 h/20`
 
 Search persons whose fields match the keywords given.
 
-Format: `search PREFIX/ KEYWORD [MORE_PREFIX/ KEYWORD ...]`
+Format: `search PREFIX/KEYWORD [MORE_PREFIX/KEYWORD ...]`
 
 * The search is case-insensitive. e.g `hans` will match `Hans`
 * Search is restricted to the fields indicated by the provided prefixes.
@@ -190,6 +190,12 @@ Format: `search PREFIX/ KEYWORD [MORE_PREFIX/ KEYWORD ...]`
 * Tag inputs must be alphanumeric
 * Only full words will be matched e.g. `friend` will not match `friends`
 * For searches with multiple prefixes, only persons matching all keywords corresponding to the prefixes will be returned
+
+Tip: Support search prefixes include:
+* `NAME`: n/
+* `TAG`: t/
+* `PHONE_NUMBER`: p/
+* `GROUP`: g/
 
 Examples: <br>
 1. **Person A:** `name`: John Doe `tag`: colleague `group`: blood drive <br>

--- a/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;
@@ -12,6 +13,7 @@ import seedu.address.logic.commands.SearchCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PhoneNumberMatchesPredicate;
 import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 /**
@@ -26,22 +28,25 @@ public class SearchCommandParser implements Parser<SearchCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public SearchCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TAG, PREFIX_GROUP_NAME);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TAG,
+                PREFIX_GROUP_NAME, PREFIX_PHONE);
 
         if (!argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_TAG, PREFIX_GROUP_NAME);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_TAG, PREFIX_GROUP_NAME, PREFIX_PHONE);
 
         String nameArgs = argMultimap.getValue(PREFIX_NAME).orElse("");
         String tagArgs = argMultimap.getValue(PREFIX_TAG).orElse("");
         String groupArgs = argMultimap.getValue(PREFIX_GROUP_NAME).orElse("");
+        String phoneArgs = argMultimap.getValue(PREFIX_PHONE).orElse("");
 
         // Check for empty inputs after the prefixes
         checkForEmptyInput(argMultimap, PREFIX_NAME, nameArgs);
         checkForEmptyInput(argMultimap, PREFIX_TAG, tagArgs);
         checkForEmptyInput(argMultimap, PREFIX_GROUP_NAME, groupArgs);
+        checkForEmptyInput(argMultimap, PREFIX_PHONE, phoneArgs);
 
         Predicate<Person> combinedPredicate = null;
 
@@ -55,6 +60,12 @@ public class SearchCommandParser implements Parser<SearchCommand> {
             TagContainsKeywordsPredicate tagPredicate =
                     new TagContainsKeywordsPredicate(Arrays.asList(tagArgs.split("\\s+")));
             combinedPredicate = combinePredicate(combinedPredicate, tagPredicate);
+        }
+
+        if (!phoneArgs.isEmpty()) {
+            PhoneNumberMatchesPredicate phonePredicate =
+                    new PhoneNumberMatchesPredicate(phoneArgs);
+            combinedPredicate = combinePredicate(combinedPredicate, phonePredicate);
         }
 
         if (combinedPredicate == null && groupArgs.isEmpty()) {

--- a/src/main/java/seedu/address/model/person/PhoneNumberMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneNumberMatchesPredicate.java
@@ -1,0 +1,42 @@
+package seedu.address.model.person;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Person}'s {@code Phone} matches exactly the given phone number.
+ */
+public class PhoneNumberMatchesPredicate implements Predicate<Person> {
+    private final String phoneNumber;
+
+    public PhoneNumberMatchesPredicate(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getPhone().value.equals(phoneNumber);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof PhoneNumberMatchesPredicate)) {
+            return false;
+        }
+        PhoneNumberMatchesPredicate otherPredicate = (PhoneNumberMatchesPredicate) other;
+        return phoneNumber.equals(otherPredicate.phoneNumber);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(phoneNumber);
+    }
+
+    @Override
+    public String toString() {
+        return "PhoneNumberMatchesPredicate{phoneNumber='" + phoneNumber + "'}";
+    }
+}


### PR DESCRIPTION
Fixes #230

Search via phone number does strict matching for the return of search results
`search p/ 1234` would only return contacts with `1234` as phone number, and would not return contact with `12345`