### PR TITLE
Fix alpha bugs for groups and wrote tests

### DIFF
--- a/src/main/java/seedu/address/logic/commands/group/AddToGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/group/AddToGroupCommand.java
@@ -101,8 +101,7 @@ public class AddToGroupCommand extends Command {
      */
     private Group createGroupWithNewMembers(Group existingGroup,
                                                      List<Index> members, List<Person> lastShownList) {
-        Group newGroup = new Group(this.groupName);
-        newGroup.setPersons(existingGroup.asUnmodifiableObservableList());
+        Group newGroup = existingGroup.copy();
         members.stream()
                 .map(member -> lastShownList.get(member.getZeroBased()))
                 .forEach(person -> {

--- a/src/main/java/seedu/address/logic/commands/group/EditGroupNameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/group/EditGroupNameCommand.java
@@ -31,7 +31,9 @@ public class EditGroupNameCommand extends Command {
             + "the new name you have chosen.";
     public static final String MESSAGE_EDIT_GROUP_NOT_FOUND = "The existing group with the given name "
             + "could not be found.";
-
+    public static final String MESSAGE_EDIT_GROUP_SAME_NAME = "The current group already has name %s. "
+            + "No changes were made.";
+    public static final String MESSAGE_EDIT_GROUP_NO_NAME = "The new group name is must be at least 1 character long!";
     private final String oldGroupName;
     private final String newGroupName;
 
@@ -48,7 +50,13 @@ public class EditGroupNameCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (oldGroupName.equals(newGroupName)) {
+            throw new CommandException(String.format(MESSAGE_EDIT_GROUP_SAME_NAME, oldGroupName));
+        }
 
+        if (newGroupName.isBlank()) {
+            throw new CommandException(MESSAGE_EDIT_GROUP_NO_NAME);
+        }
         Group existingGroup;
         try {
             existingGroup = model.getGroup(oldGroupName);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -103,6 +103,10 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     // group methods
 
+    public void updateGroupListWithEditedPerson(Person target, Person editedPerson) {
+        this.groups.updatePersonInAllGroups(target, editedPerson);
+    }
+
     /**
      * Adds {@code group} to the groups in this {@code AddressBook}.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -91,6 +91,16 @@ public interface Model {
     void updateFilteredPersonList(Predicate<Person> predicate);
 
     /**
+     * Updates all groups with the person with the edited details of the person.
+     * This method is required because person is stateless, and editing a person creates a new instance
+     * of the person which is not tracked by the respective groups.
+     *
+     * @param target The person object of the existing person
+     * @param editedPerson The new person object created by person factory.
+     */
+    void updateGroupsWithNewPerson(Person target, Person editedPerson);
+
+    /**
      * Adds {@code group} to the groups in the {@code AddressBook}.
      */
     void addGroup(Group group) throws DuplicateGroupException;

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -115,8 +115,14 @@ public class ModelManager implements Model {
     @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
-
         addressBook.setPerson(target, editedPerson);
+        updateGroupsWithNewPerson(target, editedPerson);
+    }
+
+    @Override
+    public void updateGroupsWithNewPerson(Person target, Person editedPerson) {
+        requireAllNonNull(target, editedPerson);
+        addressBook.updateGroupListWithEditedPerson(target, editedPerson);
     }
 
     @Override
@@ -230,5 +236,4 @@ public class ModelManager implements Model {
                 && filteredPersons.equals(otherModelManager.filteredPersons)
                 && sortedPersons.equals(otherModelManager.sortedPersons);
     }
-
 }

--- a/src/main/java/seedu/address/model/person/Group.java
+++ b/src/main/java/seedu/address/model/person/Group.java
@@ -35,6 +35,16 @@ public class Group extends UniquePersonList {
         return name.equals(group.name);
     }
 
+    /**
+     * Creates a copy of the current group, to prevent the group from being mutated.
+     * @return a copy of the current Group, with the same name and users.
+     */
+    public Group copy() {
+        Group newGroup = new Group(this.name);
+        newGroup.setPersons(this.asUnmodifiableObservableList());
+        return newGroup;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof Group otherGroup)) {

--- a/src/main/java/seedu/address/model/person/GroupList.java
+++ b/src/main/java/seedu/address/model/person/GroupList.java
@@ -10,6 +10,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.exceptions.DuplicateGroupException;
 import seedu.address.model.person.exceptions.GroupNotFoundException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.storage.JsonAdaptedGroup;
 
 /**
@@ -141,6 +142,22 @@ public class GroupList {
     public void set(GroupList toCopy) {
         internalList.clear();
         internalList.addAll(toCopy.internalList);
+    }
+
+    /**
+     * Update all instances of the existing {@code Person} in any groups to the edited {@code Person}.
+     *
+     * @param oldPerson the existing instance of the person.
+     * @param editedPerson the new, edited instance of the person.
+     */
+    public void updatePersonInAllGroups(Person oldPerson, Person editedPerson) {
+        internalList.forEach(group -> {
+            try {
+                group.setPerson(oldPerson, editedPerson);
+            } catch (PersonNotFoundException pnfe) {
+                // Intentionally ignoring exception, as no action need to be taken if the person isn't in any groups.
+            }
+        });
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -161,6 +161,10 @@ public class AddCommandTest {
         }
 
         @Override
+        public void updateGroupsWithNewPerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+        @Override
         public void addGroup(Group group) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/EditGroupNameCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditGroupNameCommandTest.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.testdata.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.group.EditGroupNameCommand;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.testutil.GroupBuilder;
+
+public class EditGroupNameCommandTest {
+
+    private static Model model;
+
+    @BeforeAll
+    public static void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        model.addGroup(new GroupBuilder<>().withName("NUS").build());
+    }
+
+    @Test
+    public void execute_success() {
+        EditGroupNameCommand editGroupNameCommand = new EditGroupNameCommand("NUS", "SMU");
+        String expectedMessage = String.format(EditGroupNameCommand.MESSAGE_EDIT_GROUP_SUCCESS, "NUS", "SMU");
+
+        Model expectedModel = new ModelManager(new AddressBook(getTypicalAddressBook()), new UserPrefs());
+        expectedModel.addGroup(new GroupBuilder<>().withName("SMU").build());
+
+        System.out.println("Expected: " + expectedModel.getGroupNames());
+        System.out.println("Actual: " + model.getGroupNames());
+
+        assertCommandSuccess(editGroupNameCommand, model, expectedMessage, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/testutil/GroupBuilder.java
+++ b/src/test/java/seedu/address/testutil/GroupBuilder.java
@@ -1,0 +1,56 @@
+package seedu.address.testutil;
+
+import java.util.ArrayList;
+
+import seedu.address.model.person.Group;
+import seedu.address.model.person.Person;
+
+/**
+ * A utility class to help with building Group objects.
+ * @param <T> the type of the builder (either GroupBuilder or its subclass)
+ */
+public class GroupBuilder<T extends GroupBuilder<T>> {
+    public static final String DEFAULT_NAME = "NUS_GROUP";
+    protected String name;
+    private String name1 = "Johnson Goh";
+    private String name2 = "Bravo Folly";
+    private String name3 = "Tyrone Louise";
+    private Person member1 = new PersonBuilder<>().withName(name1).build();
+    private Person member2 = new PersonBuilder<>().withName(name2).build();
+    private Person member3 = new PersonBuilder<>().withName(name3).build();
+    public GroupBuilder() {
+        this.name = DEFAULT_NAME;
+    }
+
+    /**
+     * Sets the {@code Name} of the {@code Person} that we are building.
+     */
+    public T withName(String name) {
+        this.name = name;
+        return self();
+    }
+
+    /**
+     * Builds a new group for testing
+     *
+     * @return a group with the members added and name.
+     */
+    public Group build() {
+        ArrayList<Person> members = new ArrayList<>();
+        members.add(member1);
+        members.add(member2);
+        members.add(member3);
+        Group group = new Group(name);
+        group.setPersons(members);
+        return group;
+    }
+
+    /**
+     * Returns this builder instance cast to the correct type.
+     * @return this builder
+     */
+    @SuppressWarnings("unchecked")
+    protected T self() {
+        return (T) this;
+    }
+}


### PR DESCRIPTION
Fixes
#197, #198, #200, #201.

1. #197 is fixed by adding an if block to editGroupNameCommand to throw a command exception.
2. #198 is fixed by adding an if block to editGroupNameCommand to throw a command exception.
3. #200 is fixed by updating every instance of the person which existed in any group to the new instance of the person, whenever a person is edited.
4. #201 is fixed by fixing the previous point.
5. Add some tests for editGroupNameCommand
