### PR TITLE
Improve input validation for add command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -46,7 +46,8 @@ public class AddCommandParser implements Parser<AddCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ROLE, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ROLE, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                PREFIX_ADDRESS, PREFIX_HOURS, PREFIX_DONATED_AMOUNT, PREFIX_PARTNERSHIP_END_DATE);
 
         Role role = ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).orElse(DEFAULT_ROLE));
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());


### PR DESCRIPTION
## Fixes #225

### Changes:

1. Added `PREFIX_HOURS`, `PREFIX_DONATED_AMOUNT`, and `PREFIX_PARTNERSHIP_END_DATE` to `verifyNoDuplicatePrefixesFor()` to handle invalid inputs with multiple identical fields from the user.
2. Enhanced abstraction and SLAP to `PersonFactory`. The `checkDoesNotExist()` method now takes `role`, `field`, `Optional<?>`, and `exceptionFunction`, allowing it to dynamically generate exceptions based on the required exception type.

### Rationale:

The two overloaded `createPerson()` methods both use `checkDoesNotExist()` (because we are checking for invalid fields for both `Add` and `Edit`), but they are applied in different contexts, **requiring different types of exceptions**. For instance:
- The first `createPerson()` method, which takes in an `argMultimap`, is used within the `parse()` method of `AddCommandParser`. So it needs to throw a `ParseException`.
- The second `createPerson()` method is used in the `execute()` method of `EditCommand`, requiring it to throw a `CommandException`.

Since both of these methods override parent methods, modifying their signatures is not feasible. To address this, I created two `Function` objects as static variables that can be passed to `checkDoesNotExist()`, providing the flexibility to throw different exception types as needed.

An alternative solution could be to simply overload `checkDoesNotExist()` with an `Enum` parameter to throw different types of exceptions. However, I felt this approach would be less elegant than the current solution. Let me know if you have any suggestions on this!

### Notes on `Optional<?>`:

The use of `Optional<?>` is type-safe in this context, as it is only used to check for presence (with `isPresent()`), which are type-agnostic methods. Since we are not accessing or casting the underlying value, there is no risk of `ClassCastException` or runtime issues related to type mismatches.
