### PR TITLE
Throw an exception on empty group name

### DIFF
--- a/src/main/java/seedu/address/logic/parser/group/CreateGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/group/CreateGroupCommandParser.java
@@ -19,6 +19,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parser for Commands of type CreateGroup.
  */
 public class CreateGroupCommandParser implements Parser<CreateGroupCommand> {
+    static final String GROUP_NAME_EMPTY_ERROR = "Group name cannot be empty.";
+
     @Override
     public CreateGroupCommand parse(String args) throws ParseException {
         requireNonNull(args);
@@ -31,6 +33,9 @@ public class CreateGroupCommandParser implements Parser<CreateGroupCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_GROUP_NAME, PREFIX_MEMBERS);
         String groupName = argMultimap.getValue(PREFIX_GROUP_NAME).orElse("");
+        if (groupName.trim().isEmpty()) {
+            throw new ParseException(GROUP_NAME_EMPTY_ERROR);
+        }
         String membersString = argMultimap.getValue(PREFIX_MEMBERS).orElse("");
         List<Index> members;
         try {

--- a/src/main/java/seedu/address/logic/parser/group/EditGroupNameCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/group/EditGroupNameCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser.group;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+import static seedu.address.logic.parser.group.CreateGroupCommandParser.GROUP_NAME_EMPTY_ERROR;
 
 import java.util.List;
 
@@ -27,6 +28,9 @@ public class EditGroupNameCommandParser implements Parser<EditGroupNameCommand> 
         List<String> names = argMultimap.getAllValues(PREFIX_GROUP_NAME);
         if (names.size() != 2) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditGroupNameCommand.MESSAGE_USAGE));
+        }
+        if (names.get(0).isEmpty() || names.get(1).isEmpty()) {
+            throw new ParseException(GROUP_NAME_EMPTY_ERROR);
         }
         return new EditGroupNameCommand(names.get(0), names.get(1));
     }


### PR DESCRIPTION
Applies to both createGroup and editGroupName.

Fixes #205