### PR TITLE
Improve delete to allow deletion by batch

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -16,6 +16,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_INTERVAL_INDEX = "Interval contains one or more indices out of range.";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,8 +15,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_INVALID_INTERVAL_INDEX = "Interval contains one or more indices out of range.";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "One or more indices provided are invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -35,7 +35,7 @@ public class DeleteCommand extends Command {
     private void validateIndices(List<Index> targetIndices, Integer lastShownListSize) throws CommandException {
         for (Index targetIndex : targetIndices) {
             if (targetIndex.getZeroBased() >= lastShownListSize) {
-                throw new CommandException(Messages.MESSAGE_INVALID_INTERVAL_INDEX);
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
         }
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
@@ -20,29 +21,41 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Parameters: INDICES (must be a positive integer or a range, separated by commas)\n"
+            + "Example: " + COMMAND_WORD + " 1,2,3,5-7";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: \n";
 
-    private final Index targetIndex;
+    private final List<Index> targetIndices;
 
-    public DeleteCommand(Index targetIndex) {
-        this.targetIndex = targetIndex;
+    public DeleteCommand(List<Index> targetIndices) {
+        this.targetIndices = targetIndices;
     }
 
+    private void validateIndices(List<Index> targetIndices, Integer lastShownListSize) throws CommandException {
+        for (Index targetIndex : targetIndices) {
+            if (targetIndex.getZeroBased() >= lastShownListSize) {
+                throw new CommandException(Messages.MESSAGE_INVALID_INTERVAL_INDEX);
+            }
+        }
+    }
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getPersonList();
+        List<Person> personToDeleteList = new ArrayList<>();
+        String commandResultString = MESSAGE_DELETE_PERSON_SUCCESS;
+        validateIndices(targetIndices, lastShownList.size());
+        for (Index targetIndex : targetIndices) {
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+            personToDeleteList.add(personToDelete);
+            commandResultString += Messages.format(personToDelete) + "\n";
         }
-
-        Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+        for (Person personToDelete : personToDeleteList) {
+            model.deletePerson(personToDelete);
+        }
+        return new CommandResult(commandResultString);
     }
 
     @Override
@@ -57,13 +70,13 @@ public class DeleteCommand extends Command {
         }
 
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-        return targetIndex.equals(otherDeleteCommand.targetIndex);
+        return targetIndices.equals(otherDeleteCommand.targetIndices);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("targetIndex", targetIndex)
+                .add("targetIndices", targetIndices)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -5,9 +5,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -2,8 +2,12 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.List;
+
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -18,11 +22,12 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            List<Index> indices = ParserUtil.parseIndices(args);
+            return new DeleteCommand(indices);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE) + "\nCause: "
+                            + pe.getMessage(), pe);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,6 +9,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
@@ -30,7 +33,10 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-
+    public static final String MESSAGE_INVALID_INTERVAL_FORMAT = "Invalid interval format. Expected format: a-b"
+        + ("0 < a <= b");
+    public static final String MESSAGE_INVALID_INTERVAL = "Invalid interval: start index must be less than or equal"
+            + " to end index.";
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
@@ -42,6 +48,82 @@ public class ParserUtil {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+    }
+
+    /**
+     * Parses a range in the format "a-b" into a list of {@code Index} objects.
+     *
+     * @param range The range string to parse.
+     * @return A list of {@code Index} objects from start to end of the range.
+     * @throws ParseException If the format is invalid or bounds are incorrect.
+     */
+    public static List<Index> parseInterval(String range) throws ParseException {
+        int lastHyphenIndex = range.lastIndexOf("-");
+        String[] bounds = range.split("-");
+        System.out.println(bounds.toString());
+        // Validate that the range contains exactly two parts
+        if (bounds.length != 2) {
+            throw new ParseException(MESSAGE_INVALID_INTERVAL_FORMAT);
+        }
+
+        // Parse start and end indices
+        Index startIndex = parseIndex(bounds[0]);
+        Index endIndex = parseIndex(bounds[1]);
+
+        // Validate that startIndex is less than or equal to endIndex
+        if (startIndex.getOneBased() > endIndex.getOneBased()) {
+            throw new ParseException(MESSAGE_INVALID_INTERVAL);
+        }
+
+        // Generate and return the list of indices from start to end
+        return IntStream.rangeClosed(startIndex.getOneBased(), endIndex.getOneBased())
+                .mapToObj(Index::fromOneBased)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Parses a string containing indices and ranges (e.g., "1,2,3,5-9") into a list of {@code Index} objects.
+     * Accepts both single indices and ranges separated by spaces.
+     *
+     * @param args The string containing indices and/or ranges to parse.
+     * @return A list of {@code Index} objects representing the parsed indices and ranges.
+     * @throws ParseException If any part of the input is not a valid index or range.
+     */
+    public static List<Index> parseIndices(String args) throws ParseException {
+        requireNonNull(args);
+        String trimmedIndices = args.trim();
+
+        try {
+            return Arrays.stream(trimmedIndices.split(","))
+                    .flatMap(arg -> parseArgAsStream(arg))
+                    .collect(Collectors.toList());
+        } catch (RuntimeException e) {
+            String causeMessage = e.getCause().getMessage();
+            System.out.println(causeMessage);
+            // Catch any ParseExceptions wrapped in RuntimeExceptions
+            throw new ParseException(causeMessage, e);
+        }
+    }
+
+    /**
+     * Parses a single argument as either an interval (e.g., "5-9") or a single index (e.g., "3"),
+     * returning a stream of {@code Index} objects. This allows for processing both individual indices
+     * and ranges within a stream context.
+     *
+     * @param arg The argument string to parse as an index or interval.
+     * @return A stream of {@code Index} objects parsed from the argument.
+     * @throws RuntimeException wrapping a {@code ParseException} if the argument is invalid.
+     */
+    private static Stream<Index> parseArgAsStream(String arg) {
+        try {
+            if (arg.contains("-")) {
+                return parseInterval(arg).stream();
+            } else {
+                return Stream.of(parseIndex(arg));
+            }
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -10,6 +10,8 @@ import static seedu.address.testutil.testdata.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.testdata.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.testdata.TypicalPersons.getTypicalAddressBook;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
@@ -30,10 +32,9 @@ public class DeleteCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(INDEX_FIRST_PERSON));
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
-                Messages.format(personToDelete));
+        String expectedMessage = DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS + Messages.format(personToDelete) + "\n";
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
@@ -44,7 +45,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getPersonList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(outOfBoundIndex));
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -54,10 +55,9 @@ public class DeleteCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personToDelete = model.getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(INDEX_FIRST_PERSON));
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
-                Messages.format(personToDelete));
+        String expectedMessage = DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS + Messages.format(personToDelete) + "\n";
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
@@ -74,21 +74,21 @@ public class DeleteCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(outOfBoundIndex));
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(List.of(INDEX_FIRST_PERSON));
+        DeleteCommand deleteSecondCommand = new DeleteCommand(List.of(INDEX_SECOND_PERSON));
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(List.of(INDEX_FIRST_PERSON));
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false
@@ -104,8 +104,8 @@ public class DeleteCommandTest {
     @Test
     public void toStringMethod() {
         Index targetIndex = Index.fromOneBased(1);
-        DeleteCommand deleteCommand = new DeleteCommand(targetIndex);
-        String expected = DeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(targetIndex));
+        String expected = DeleteCommand.class.getCanonicalName() + "{targetIndices=[" + targetIndex + "]}";
         assertEquals(expected, deleteCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -51,7 +51,7 @@ public class AddressBookParserTest {
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+        assertEquals(new DeleteCommand(List.of(INDEX_FIRST_PERSON)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -5,6 +5,8 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.testdata.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
@@ -22,7 +24,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, "1", new DeleteCommand(List.of(INDEX_FIRST_PERSON)));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -29,6 +29,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE)
+                + "\nCause: " + ParserUtil.MESSAGE_INVALID_INDEX);
     }
 }


### PR DESCRIPTION
Fixes #251 
`Delete` now supports deletion by batch

Example:
`
delete 1,2,3,5-9
`
Single Index`(1,2,3)` and Intervals`(4-6)` can appear at the same time, separated by commas.