### PR TITLE
Fix issue with deleting person in group

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -99,6 +99,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePerson(Person key) {
         persons.remove(key);
+        groups.removePersonInAllGroups(key);
     }
 
     // group methods

--- a/src/main/java/seedu/address/model/person/Group.java
+++ b/src/main/java/seedu/address/model/person/Group.java
@@ -47,6 +47,13 @@ public class Group extends UniquePersonList {
         return name.equals(group.name);
     }
 
+    /**
+     * Returns the number of persons in the group.
+     */
+    public int size() {
+        return asUnmodifiableObservableList().size();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof Group otherGroup)) {

--- a/src/main/java/seedu/address/model/person/GroupList.java
+++ b/src/main/java/seedu/address/model/person/GroupList.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -158,6 +159,26 @@ public class GroupList {
                 // Intentionally ignoring exception, as no action need to be taken if the person isn't in any groups.
             }
         });
+    }
+
+    /**
+     * Removes all instances of {@code deletedPerson} in any groups.
+     */
+    public void removePersonInAllGroups(Person deletedPerson) {
+        List<String> groupsToDelete = new ArrayList<>();
+        internalList.forEach(group -> {
+            try {
+                group.remove(deletedPerson);
+                if (group.size() == 0) {
+                    groupsToDelete.add(group.getName());
+                }
+            } catch (PersonNotFoundException pnfe) {
+                // Intentionally ignoring exception, as no action need to be taken if the person isn't in any groups.
+            }
+        });
+        for(String groupName : groupsToDelete) {
+            remove(groupName);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/GroupList.java
+++ b/src/main/java/seedu/address/model/person/GroupList.java
@@ -176,7 +176,7 @@ public class GroupList {
                 // Intentionally ignoring exception, as no action need to be taken if the person isn't in any groups.
             }
         });
-        for(String groupName : groupsToDelete) {
+        for (String groupName : groupsToDelete) {
             remove(groupName);
         }
     }


### PR DESCRIPTION
After deleting a person, the change was not being reflected accurately in groups which they were in. Groups were also still persisting with zero members left.

Groups now update upon deletion of person and are automatically removed upon reaching zero members.

Note that the issue of the person being displayed in the Group UI (in the short member synopsis) after being deleted still persists.