### PR TITLE
Fix grammar for search command result

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,7 +18,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "One or more indices provided are invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%d %s listed!";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%d person(s) listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_INVALID_COMMAND_FOR_PERSON_TYPE =

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,7 +18,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "One or more indices provided are invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%d %s listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_INVALID_COMMAND_FOR_PERSON_TYPE =

--- a/src/main/java/seedu/address/logic/commands/SearchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SearchCommand.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Group;

--- a/src/main/java/seedu/address/logic/commands/SearchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SearchCommand.java
@@ -74,7 +74,7 @@ public class SearchCommand extends Command {
         model.updateFilteredPersonList(finalPredicate);
         int resultSize = model.getPersonList().size();
 
-        String personOrPersons = (resultSize <= 1) ? "person" : "persons";
+        String personOrPersons = (resultSize == 1) ? "person" : "persons";
         String message = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, resultSize, personOrPersons);
 
         // Return the command result with the dynamic message

--- a/src/main/java/seedu/address/logic/commands/SearchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SearchCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 
 import java.util.function.Predicate;
 
@@ -72,8 +73,13 @@ public class SearchCommand extends Command {
             }
         }
         model.updateFilteredPersonList(finalPredicate);
-        return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getPersonList().size()));
+        int resultSize = model.getPersonList().size();
+
+        String personOrPersons = (resultSize <= 1) ? "person" : "persons";
+        String message = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, resultSize, personOrPersons);
+
+        // Return the command result with the dynamic message
+        return new CommandResult(message);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/SearchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SearchCommand.java
@@ -72,13 +72,9 @@ public class SearchCommand extends Command {
             }
         }
         model.updateFilteredPersonList(finalPredicate);
-        int resultSize = model.getPersonList().size();
-
-        String personOrPersons = (resultSize == 1) ? "person" : "persons";
-        String message = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, resultSize, personOrPersons);
 
         // Return the command result with the dynamic message
-        return new CommandResult(message);
+        return new CommandResult(String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, model.getPersonList().size()));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
@@ -62,7 +62,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_zeroNameKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0, "person");
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0, "persons");
         NameContainsKeywordsPredicate predicate = prepareNamePredicate(" ");
         SearchCommand command = new SearchCommand(predicate, null);
         expectedModel.updateFilteredPersonList(predicate);
@@ -82,7 +82,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_zeroTagKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0, "person");
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0, "persons");
         TagContainsKeywordsPredicate predicate = prepareTagPredicate(" ");
         SearchCommand command = new SearchCommand(predicate, null);
         expectedModel.updateFilteredPersonList(predicate);
@@ -124,7 +124,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_nameAndTagSearch_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0, "person");
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0, "persons");
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("NonExistentName");
         TagContainsKeywordsPredicate tagPredicate = prepareTagPredicate("friend");
         Predicate<Person> combinedPredicate = namePredicate.and(tagPredicate);

--- a/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
@@ -62,7 +62,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_zeroNameKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0, "person");
         NameContainsKeywordsPredicate predicate = prepareNamePredicate(" ");
         SearchCommand command = new SearchCommand(predicate, null);
         expectedModel.updateFilteredPersonList(predicate);
@@ -72,7 +72,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_multipleNameKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3, "persons");
         NameContainsKeywordsPredicate predicate = prepareNamePredicate("Kurz Elle Kunz");
         SearchCommand command = new SearchCommand(predicate, null);
         expectedModel.updateFilteredPersonList(predicate);
@@ -82,7 +82,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_zeroTagKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0, "person");
         TagContainsKeywordsPredicate predicate = prepareTagPredicate(" ");
         SearchCommand command = new SearchCommand(predicate, null);
         expectedModel.updateFilteredPersonList(predicate);
@@ -92,7 +92,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_singleTagKeyword_singlePersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1, "person");
         TagContainsKeywordsPredicate predicate = prepareTagPredicate("owesMoney");
         SearchCommand command = new SearchCommand(predicate, null);
         expectedModel.updateFilteredPersonList(predicate);
@@ -102,7 +102,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_multipleTagKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3, "persons");
         TagContainsKeywordsPredicate predicate = prepareTagPredicate("friends");
         SearchCommand command = new SearchCommand(predicate, null);
         expectedModel.updateFilteredPersonList(predicate);
@@ -112,7 +112,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_nameAndTagSearch_combinedSearchFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1, "person");
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Alice");
         TagContainsKeywordsPredicate tagPredicate = prepareTagPredicate("friends");
         Predicate<Person> combinedPredicate = namePredicate.and(tagPredicate);
@@ -124,7 +124,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_nameAndTagSearch_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0, "person");
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("NonExistentName");
         TagContainsKeywordsPredicate tagPredicate = prepareTagPredicate("friend");
         Predicate<Person> combinedPredicate = namePredicate.and(tagPredicate);

--- a/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
@@ -62,7 +62,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_zeroNameKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0, "persons");
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = prepareNamePredicate(" ");
         SearchCommand command = new SearchCommand(predicate, null);
         expectedModel.updateFilteredPersonList(predicate);
@@ -72,7 +72,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_multipleNameKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3, "persons");
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         NameContainsKeywordsPredicate predicate = prepareNamePredicate("Kurz Elle Kunz");
         SearchCommand command = new SearchCommand(predicate, null);
         expectedModel.updateFilteredPersonList(predicate);
@@ -82,7 +82,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_zeroTagKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0, "persons");
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         TagContainsKeywordsPredicate predicate = prepareTagPredicate(" ");
         SearchCommand command = new SearchCommand(predicate, null);
         expectedModel.updateFilteredPersonList(predicate);
@@ -92,7 +92,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_singleTagKeyword_singlePersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1, "person");
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
         TagContainsKeywordsPredicate predicate = prepareTagPredicate("owesMoney");
         SearchCommand command = new SearchCommand(predicate, null);
         expectedModel.updateFilteredPersonList(predicate);
@@ -102,7 +102,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_multipleTagKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3, "persons");
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         TagContainsKeywordsPredicate predicate = prepareTagPredicate("friends");
         SearchCommand command = new SearchCommand(predicate, null);
         expectedModel.updateFilteredPersonList(predicate);
@@ -112,7 +112,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_nameAndTagSearch_combinedSearchFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1, "person");
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Alice");
         TagContainsKeywordsPredicate tagPredicate = prepareTagPredicate("friends");
         Predicate<Person> combinedPredicate = namePredicate.and(tagPredicate);
@@ -124,7 +124,7 @@ public class SearchCommandTest {
 
     @Test
     public void execute_nameAndTagSearch_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0, "persons");
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("NonExistentName");
         TagContainsKeywordsPredicate tagPredicate = prepareTagPredicate("friend");
         Predicate<Person> combinedPredicate = namePredicate.and(tagPredicate);


### PR DESCRIPTION
- If the number of person returned in the result is less than or equals to 1, it would be 'person'
- If the number  is 2 or greater, it would be 'persons'

Fixes #416 